### PR TITLE
Overhauled Markdown completely

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribution Guidelines
 
-**`Last updated: 2021-07-24`**
+**`Last updated: 2021-07-25`**
 
 Your submission **must**:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,14 +19,14 @@ Your submission **must not**:
 <summary>Footnotes</summary>
 <br>
 
-<b id="1">support server:</b> A support server can be any of:
+<sup id="1">**1**</sup> A "support server" can be any of:
 
 - Website
 - Subreddit or other forum
 - Discord/Guilded server
 - *others may be accepted; if in doubt, try it, and you'll be asked to change it if it's a problem*
 
-<b id="2">skid:</b> We define a "skid" as:
+<sup id="2">**2**</sup> We define a "skid" as:
 
 > taking others code and passing it off as your own and not crediting the original work
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,40 @@
 # Contribution Guidelines
 
-Ensure your pull request adheres to the following guidelines:
+**`Last updated: 2021-07-24`**
 
-- Your submission must be a **new** Minecraft client.
-- Your submission must use the same formatting as the other clients.
-- Your submission must include either a link to your source code or support server<sup>[1](#2)</sup>.
-- Your submission is not a skid<sup>[1](#1)</sup>.
-- Your submission is added to the relevant category.
-- Your submission doesn't including spelling or grammar errors.
-- Your pull request at time of submission is up to date with the current branch.
+Your submission **must**:
 
-<b id="1">skid:</b> We define a skid as taking others code and passing it off as your own and not crediting the original work. A skid should not be confused with a [port](https://en.wikipedia.org/wiki/Porting) or a [fork](https://en.wikipedia.org/wiki/Fork_(software_development)).
+- follow the formatting style of the existing entries
+- include either a link to your source code or support server<sup>[1]</sup>
+- be placed in the proper modloader category
+- be up-to-date with the current upstream `master` branch
 
-<b id="2">support server:</b> A support server can be anything from a Website, Forum, Guilded or Discord Server, aslong it allows people to stay upto date with your submission.
+Your submission **must not**:
+
+- be a skid<sup>[2]</sup>
+- already exist in the index
+- have spelling or grammar errors
+
+<details>
+<summary>Footnotes</summary>
+<br>
+
+<b id="1">support server:</b> A support server can be any of:
+
+- Website
+- Subreddit or other forum
+- Discord/Guilded server
+- *others may be accepted; if in doubt, try it, and you'll be asked to change it if it's a problem*
+
+<b id="2">skid:</b> We define a "skid" as:
+
+> taking others code and passing it off as your own and not crediting the original work
+
+Please note that a skid should **not** be confused with a [port] or a [fork]. Some mods may include the term "skid" in their title, but this is not an official indicator of a skid.
+
+</details>
+
+[1]: #1
+[2]: #2
+[port]: https://en.wikipedia.org/wiki/Porting
+[fork]: https://en.wikipedia.org/wiki/Fork_(software_development)

--- a/README.md
+++ b/README.md
@@ -215,12 +215,12 @@ Please consult the [Contribution Guidelines] before opening an Issue or a Pull R
 ---
 ## Footnotes
 
-<sup id="fn1">1</sup> Older Minecraft versions may be using Forge.  
-<sup id="fn2">2</sup> KAMI should **not** be confused with the "Kami Blue" utility mod, which has been archived and is no longer maintained.  
-<sup id="fn3">3</sup> Quantum itself is not open-source, but the developers have published the source code for some tools Quantum uses.  
-<sup id="fn4">4</sup> beach house itself is not open-source, but the developers have published the source code for some tools beach house uses.  
-<sup id="fn5">5</sup> Impact is also available as a standalone mod.  
-<sup id="fn6">6</sup> Impact previously had a Discord server but it was terminated in a Discord ban-wave.  
+<sup id="fn1">**1**</sup> Older Minecraft versions may be using Forge.  
+<sup id="fn2">**2**</sup> KAMI should **not** be confused with the "Kami Blue" utility mod, which has been archived and is no longer maintained.  
+<sup id="fn3">**3**</sup> Quantum itself is not open-source, but the developers have published the source code for some tools Quantum uses.  
+<sup id="fn4">**4**</sup> beach house itself is not open-source, but the developers have published the source code for some tools beach house uses.  
+<sup id="fn5">**5**</sup> Impact is also available as a standalone mod.  
+<sup id="fn6">**6**</sup> Impact previously had a Discord server but it was terminated in a Discord ban-wave.  
 
 [1]: #fn1
 [2]: #fn2

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Minecraft Utility Mod Index
 
 Please consult the [Contribution Guidelines](https://github.com/UtilityMods/Index/blob/main/CONTRIBUTING.md) before opening an Issue or a Pull Request.
 
+## Mod index
+
+The index includes clients for Fabric, Forge, and Standalone, with version support from 1.12 to 1.17. It is alphabetically sorted by mod name and categorized by the modloader.
+
 ### Fabric
 
 | Name | Version | Support | Source | Development Status |

--- a/README.md
+++ b/README.md
@@ -37,21 +37,17 @@ A modloader is exactly what it sounds like: it loads mods, hence "mod loader". T
 | Name | Version | Links |
 | :--: | :-----: | :---: |
 | [Ares]          | **1.16.4**           | [Discord][Ares Discord]<br>[GitHub][Ares GitHub] |
-| [Aristois]      | **1.8.9 to 1.17.1**\*<sup>1</sup> | [Forum][Aristois forum] |
+| [Aristois]      | **1.8.9 to 1.17.1**<sup>[1]</sup> | [Forum][Aristois forum] |
 | Atomic          | **1.17**             | [Discord][Atomic Discord]<br>[GitHub][Atmoic GitHub] |
 | [Bleach]        | **1.16.5 to 1.17.1** | [Discord][Bleach Discord]<br>[GitHub][Bleach GitHub] |
 | FrostBurn       | **1.17**             | [Discord][FrostBurn Discord]<br>[GitHub][FrostBurn GitHub] |
 | [Inertia]       | **1.14.4 to 1.16.5** | [Discord][Inertia Discord] |
 | [Jex]           | **1.17**             | [Discord][Jex Discord]<br>[Github][Jex GitHub] |
-| [KAMI]\*<sup>2</sup> | **1.16.5**      | [Discord][KAMI Discord]<br>[GitHub][KAMI GitHub] |
+| [KAMI]<sup>[2]</sup> | **1.16.5**      | [Discord][KAMI Discord]<br>[GitHub][KAMI GitHub] |
 | [Meteor Client] | **1.17.1**           | [Discord][Meteor Discord]<br>[GitHub][Meteor GitHub] |
-| [Quantum]       |  **1.17**            | [Discord][Quantum Discord]<br>[GitHub][Quantum GitHub]\*<sup>3</sup> |
+| [Quantum]       |  **1.17**            | [Discord][Quantum Discord]<br>[GitHub][Quantum GitHub]<sup>[3]</sup> |
 | Toast Client    | **1.16.5**           | [Discord][Toast Discord]<br>[GitHub][Toast GitHub] |
-| [Wurst]         | **1.7.2 to 1.17.1+**\*<sup>1</sup> | [Reddit][Wurst Reddit]<br>[GitHub][Wurst GitHub] |
-
-\*<sup>1</sup> Older Minecraft versions may be using Forge.  
-\*<sup>2</sup> KAMI should **not** be confused with the "Kami Blue" utility mod, which has been archived and is no longer maintained.  
-\*<sup>3</sup> Quantum itself is not open-source, but the developers have published the source code for some tools Quantum uses.  
+| [Wurst]         | **1.7.2 to 1.17.1+**<sup>[1]</sup> | [Reddit][Wurst Reddit]<br>[GitHub][Wurst GitHub] |
 
 [Aristois]: https://aristois.net/
 [Aristois forum]: https://discuss.aristois.net/
@@ -102,7 +98,7 @@ A modloader is exactly what it sounds like: it loads mods, hence "mod loader". T
 
 | Name | Version | Links | Status |
 | :--: | :-----: | :---: | :----: |
-| [beach house]  |  **1.16.5?**  | [GitHub][beach house GitHub]\*<sup>1</sup> | WIP |
+| [beach house]  |  **1.16.5?** | [GitHub][beach house GitHub]<sup>[4]</sup> | WIP |
 | Bleach epearl edition | **1.16.4** | [Discord][Bleach epearl Discord]<br>[GitHub][Bleach epearl GitHub] | Archived |
 | BubbyClient    | **1.16.1**   | [GitHub][Bubby GitHub] | Archived |
 | [Cornos]       | **1.16.5**   | [Discord][Cornos Discord]<br>[GitHub][Cornos GitHub] | Archived |
@@ -113,8 +109,6 @@ A modloader is exactly what it sounds like: it loads mods, hence "mod loader". T
 | MineClient     |  **1.16.5**  | [Discord][MineClient Discord]<br>[Github][MineClient GitHub] | Archived |
 | Numa           |  **1.16.5**  | [Forum][Numa Forum]<br>*may be offline* | WIP |
 | Phobos-1.16    | **1.16.5**   | [Github][Phobos-1.16 GitHub] | Archived |
-
-\*<sup>1</sup> beach house itself is not open-source, but the developers have published the source code for some tools beach house uses.  
 
 [beach house]: https://beach-house-development.github.io/website/
 [beach house GitHub]: https://github.com/beach-house-development
@@ -143,11 +137,8 @@ A modloader is exactly what it sounds like: it loads mods, hence "mod loader". T
 
 | Name | Version | Links |
 | :--: | :-----: | :---: |
-| [Impact]\*<sup>1</sup> | **1.11.2 to 1.16.5** | [Issues][Impact Issues]\*<sup>2</sup> |
+| [Impact]<sup>[5]</sup> | **1.11.2 to 1.16.5** | [Issues][Impact Issues]<sup>[6]</sup> |
 | [Seppuku] | **1.12.2** | [Discord][Seppuku Discord]<br>[GitHub][Seppuku GitHub] |
-
-\*<sup>1</sup> Impact is also available as a standalone mod.  
-\*<sup>2</sup> Impact previously had a Discord server but it was terminated in a Discord ban-wave.  
 
 #### Fabric mods with Forge variants
 
@@ -220,3 +211,20 @@ These Fabric mods [listed above](#fabric) also offer Forge variants. These are t
 Please consult the [Contribution Guidelines] before opening an Issue or a Pull Request.
 
 [Contribution Guidelines]: https://github.com/UtilityMods/Index/blob/main/CONTRIBUTING.md
+
+---
+## Footnotes
+
+<sup id="fn1">1</sup> Older Minecraft versions may be using Forge.  
+<sup id="fn2">2</sup> KAMI should **not** be confused with the "Kami Blue" utility mod, which has been archived and is no longer maintained.  
+<sup id="fn3">3</sup> Quantum itself is not open-source, but the developers have published the source code for some tools Quantum uses.  
+<sup id="fn4">4</sup> beach house itself is not open-source, but the developers have published the source code for some tools beach house uses.  
+<sup id="fn5">5</sup> Impact is also available as a standalone mod.  
+<sup id="fn6">6</sup> Impact previously had a Discord server but it was terminated in a Discord ban-wave.  
+
+[1]: #fn1
+[2]: #fn2
+[3]: #fn3
+[4]: #fn4
+[5]: #fn5
+[6]: #fn6

--- a/README.md
+++ b/README.md
@@ -212,7 +212,6 @@ Please consult the [Contribution Guidelines] before opening an Issue or a Pull R
 
 [Contribution Guidelines]: https://github.com/UtilityMods/Index/blob/main/CONTRIBUTING.md
 
----
 ## Footnotes
 
 <sup id="fn1">**1**</sup> Older Minecraft versions may be using Forge.  

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A modloader is exactly what it sounds like: it loads mods, hence "mod loader". T
 
 </details>
 
-
+---
 ### Fabric
 
 | Name | Version | Links |
@@ -137,7 +137,7 @@ A modloader is exactly what it sounds like: it loads mods, hence "mod loader". T
 
 </details>
 
-
+---
 ### Forge
 
 | Name | Version | Links |
@@ -193,7 +193,7 @@ These Fabric mods [listed above](#fabric) also offer Forge variants. These are t
 
 </details>
 
-
+---
 ### Standalone
 
 | Name | Version | Links | Notes |
@@ -213,7 +213,7 @@ These Fabric mods [listed above](#fabric) also offer Forge variants. These are t
 
 </details>
 
-
+---
 ## Contributing
 
 Please consult the [Contribution Guidelines] before opening an Issue or a Pull Request.

--- a/README.md
+++ b/README.md
@@ -34,55 +34,185 @@ A modloader is exactly what it sounds like: it loads mods, hence "mod loader". T
 
 ### Fabric
 
-| Name | Version | Support | Source | Development Status |
-|:-:|:-:|:-:|:-:|:-:|
-| [Aristois](https://aristois.net/) | **1.17.1** | [Forum](https://discuss.aristois.net/) | Closed | Active |
-| [Ares](https://aresclient.org/) | **1.16.5** | [Discord](https://discord.com/invite/GtBgknj) | [GitHub](https://github.com/AresClient/ares) | Active |
-| Atomic | **1.17.1** | [Discord](https://discord.gg/rvC7F798xQ) | [GitHub](https://github.com/cornos/Atomic) | Active |
-| [Bleach](https://bleachhack.github.io) | **1.16/1.17** | [Discord](https://bleachhack.github.io/discord) | [GitHub](https://github.com/BleachDrinker420/bleachhack-1.14) | Active |
-| FrostBurn | **1.17** | [Discord](https://discord.gg/XkpYgpfHtc) | [GitHub](https://github.com/evaan/FrostBurn) | Active |
-| [Inertia](https://inertiaclient.com/) | **1.16.5** | [Discord](https://discord.com/invite/ZyMKgSm) | Closed | Active |
-| [Jex](https://jexclient.com) | **1.17.1** | [Discord](https://discord.gg/6sCnhXuAG6) | [Github](https://github.com/DustinRepo/JexClient-main) | Active
-| [KAMI](https://kamiclient.com) | **1.16.5** | [Discord](https://discord.gg/9hvwgeg) | [GitHub](https://github.com/zeroeightysix/KAMI) | Active |
-| [Meteor Client](https://meteorclient.com/) | **1.17.1** | [Discord](https://discord.com/invite/bBGQZvd) | [GitHub](https://github.com/MeteorDevelopment/meteor-client) | Active |
-| [Quantum](https://quantumclient.org/) |  **1.17.1**  | [Discord](https://discord.gg/DC358waTEZ) | Closed | Active |
-| Toast Client | **1.16.5** | [Discord](https://discord.gg/PASHZanfyc) | [GitHub](https://github.com/RemainingToast/ToastClient) | Active |
-| [Wurst](https://www.wurstclient.net/) | **1.17.1** | [Reddit](https://www.reddit.com/r/WurstClient/) | [GitHub](https://github.com/Wurst-Imperium/Wurst7) | Active |
+| Name | Version | Links |
+| :--: | :-----: | :---: |
+| [Ares]          | **1.16.4**           | [Discord][Ares Discord]<br>[GitHub][Ares GitHub] |
+| [Aristois]      | **1.8.9 to 1.17.1**<br><small>*older versions may use Forge*</small> | [Forum][Aristois forum] |
+| Atomic          | **1.17**             | [Discord][Atomic Discord]<br>[GitHub][Atmoic GitHub] |
+| [Bleach]        | **1.16.5 to 1.17.1** | [Discord][Bleach Discord]<br>[GitHub][Bleach GitHub] |
+| FrostBurn       | **1.17**             | [Discord][FrostBurn Discord]<br>[GitHub][FrostBurn GitHub] |
+| [Inertia]       | **1.14.4 to 1.16.5** | [Discord][Inertia Discord] |
+| [Jex]           | **1.17**             | [Discord][Jex Discord]<br>[Github][Jex GitHub] |
+| [KAMI]*         | **1.16.5**           | [Discord][KAMI Discord]<br>[GitHub][KAMI GitHub] |
+| [Meteor Client] | **1.17.1**           | [Discord][Meteor Discord]<br>[GitHub][Meteor GitHub] |
+| [Quantum]       |  **1.17**            | [Discord][Quantum Discord]<br>[GitHub][Quantum GitHub]* |
+| Toast Client    | **1.16.5**           | [Discord][Toast Discord]<br>[GitHub][Toast GitHub] |
+| [Wurst]         | **1.7.2 to 1.17.1+**<br><small>*older versions may use Forge*</small> | [Reddit][Wurst Reddit]<br>[GitHub][Wurst GitHub] |
 
-#### Archived/WIP
-| Name | Version | Support | Source | Development Status |
-|:-:|:-:|:-:|:-:|:-:|
-| [beach house](https://beach-house-development.github.io/website/) |  **1.16.5**  | N/A | Closed | WIP |
-| Bleach epearl edition | **1.16.4** | [Discord](https://discord.com/invite/WkdpPZ6) | [GitHub](https://github.com/22s/bleachhack-1.16-epearl-edition) | Archived |
-| BubbyClient | **1.16.1** | N/A | [GitHub](https://github.com/BubbyRoosh1/BubbyClient-Fabric-1.16) | Archived |
-| [Cornos](https://cornos.cf) | **1.16.5** | [Discord](https://discord.gg/rvC7F798xQ) | [GitHub](https://github.com/cornos/Cornos) | Archived |
-| FaxHax | **1.16.5** | [Discord](https://discord.gg/D6XqgbVGFT) | [GitHub](https://github.com/FaxHax/fabric-client) | Archived |
-| GS-Fabric | **1.16.5** | N/A | [GitHub](https://github.com/IUDevman/gamesense-fabric) | Archived |
-| [LiquidBounce](https://liquidbounce.net) | **1.17.1** | [Guilded](https://www.guilded.gg/CCBlueX) | [GitHub](https://github.com/CCBlueX/LiquidBounce) | WIP |
-| Lumen | **1.16.5** | N/A | [GitHub](https://github.com/olliem5/lumen) | Archived |
-| MineClient |  **1.16.5**  | [Discord](https://discord.gg/DC358waTEZ) | [Github](https://github.com/ChiquitaV2/MineClient) | Archived |
-| Numa |  **1.16.5**  | [Forum](https://numaclient.net/) | Closed | WIP |
-| Phobos-1.16 | **1.16.5** | N/A | [Github](https://github.com/MOMIN5/Phobos-1.16) | Archived |
+\* KAMI should **not** be confused with the "Kami Blue" utility mod, which has been archived and is no longer maintained.  
+\* Quantum itself is not open-source, but the developers have published the source code for some tools Quantum uses.
+
+[Aristois]: https://aristois.net/
+[Aristois forum]: https://discuss.aristois.net/
+
+[Ares]: https://aresclient.org/
+[Ares Discord]: https://discord.com/invite/3cdCacJ
+[Ares GitHub]: https://github.com/AresClient
+
+[Atomic Discord]: https://discord.gg/rvC7F798xQ 
+[Atmoic GitHub]: https://github.com/cornos/Atomic
+
+[Bleach]: https://bleachhack.org/
+[Bleach Discord]: https://bleachhack.org/discord
+[Bleach GitHub]: https://github.com/BleachDrinker420/BleachHack
+
+[FrostBurn Discord]: https://discord.gg/XkpYgpfHtc
+[FrostBurn GitHub]: https://github.com/evaan/FrostBurn
+
+[Inertia]: https://inertiaclient.com/
+[Inertia Discord]: https://discord.gg/ZyMKgSm
+
+[Jex]: https://jexclient.com
+[Jex Discord]: https://discord.gg/msV9ek4Qwt
+[Jex GitHub]: https://github.com/DustinRepo/JexClient-main
+
+[KAMI]: https://kamiclient.com
+[KAMI Discord]: https://discord.gg/9hvwgeg
+[KAMI GitHub]: https://github.com/zeroeightysix/KAMI
+
+[Meteor Client]: https://meteorclient.com/
+[Meteor Discord]: https://meteorclient.com/discord
+[Meteor GitHub]: https://meteorclient.com/github
+
+[Quantum]: https://quantumclient.org/
+[Quantum Discord]: https://quantumclient.org/discord
+[Quantum GitHub]: https://quantumclient.org/github
+
+[Toast Discord]: https://discord.gg/PASHZanfyc
+[Toast GitHub]: https://github.com/RemainingToast/ToastClient
+
+[Wurst]: https://www.wurstclient.net/
+[Wurst Reddit]: https://www.reddit.com/r/WurstClient/
+[Wurst GitHub]: https://github.com/Wurst-Imperium/Wurst7
+
+#### Archived & WIP (Fabric)
+<details>
+<summary><em>Expand list</em></summary>
+
+| Name | Version | Links | Status |
+| :--: | :-----: | :---: | :----: |
+| [beach house]  |  **1.16.5?**  | [GitHub][beach house GitHub]* | WIP |
+| Bleach epearl edition | **1.16.4** | [Discord][Bleach epearl Discord]<br>[GitHub][Bleach epearl GitHub] | Archived |
+| BubbyClient    | **1.16.1**   | [GitHub][Bubby GitHub] | Archived |
+| [Cornos]       | **1.16.5**   | [Discord][Cornos Discord]<br>[GitHub][Cornos GitHub] | Archived |
+| FaxHax         | **1.16.5**   | [Discord][FaxHax Discord]<br>[GitHub][FaxHax GitHub] | Archived |
+| GS-Fabric      | **1.16.5**   | [GitHub][GS-Fabric] | Archived |
+| [LiquidBounce] | **1.17.1**   | [Guilded][Liquid Guilded]<br>[GitHub][Liquid GitHub] | WIP |
+| Lumen          | **1.16.5**   | [GitHub][Lumen GitHub] | Archived |
+| MineClient     |  **1.16.5**  | [Discord][MineClient Discord]<br>[Github][MineClient GitHub] | Archived |
+| Numa           |  **1.16.5**  | [Forum][Numa Forum]<br>*may be offline* | WIP |
+| Phobos-1.16    | **1.16.5**   | [Github][Phobos-1.16 GitHub] | Archived |
+
+\* beach house itself is not open-source, but the developers have published the source code for some tools beach house uses.
+
+[beach house]: https://beach-house-development.github.io/website/
+[beach house GitHub]: https://github.com/beach-house-development
+[Bleach epearl Discord]: https://discord.com/invite/WkdpPZ6
+[Bleach epearl GitHub]: https://github.com/22s/bleachhack-1.16-epearl-edition
+[Bubby GitHub]: https://github.com/BubbyRoosh1/BubbyClient-Fabric-1.16
+[Cornos]: https://cornos.cf/
+[Cornos Discord]: https://discord.gg/rvC7F798xQ
+[Cornos GitHub]: https://github.com/cornos/Cornos
+[FaxHax Discord]: https://discord.gg/D6XqgbVGFT
+[FaxHax GitHub]: https://github.com/FaxHax/fabric-client
+[GS-Fabric]: https://github.com/IUDevman/gamesense-fabric
+[LiquidBounce]: https://liquidbounce.net
+[Liquid Guilded]: https://www.guilded.gg/CCBlueX
+[Liquid GitHub]: https://github.com/CCBlueX/LiquidBounce
+[Lumen GitHub]: https://github.com/olliem5/lumen
+[MineClient Discord]: https://discord.gg/DC358waTEZ
+[MineClient GitHub]: https://github.com/ChiquitaV2/MineClient
+[Numa Forum]: https://numaclient.net/
+[Phobos-1.16 GitHub]: https://github.com/MOMIN5/Phobos-1.16
+
+</details>
+
+
+### Forge
+
+| Name | Version | Links |
+| :--: | :-----: | :---: |
+| [Impact]* | **1.11.2 to 1.16.5** | [Issues][Impact Issues]* |
+| [Seppuku] | **1.12.2** | [Discord][Seppuku Discord]<br>[GitHub][Seppuku GitHub] |
+
+\* Impact is also available as a standalone mod.
+\* Impact previously had a Discord server but it was terminated in a Discord ban-wave.
+
+#### Fabric mods with Forge variants
+
+- Ares
+- Aristois
+- Inertia
+- Wurst
+
+These Fabric mods [listed above](#fabric) also offer Forge variants. These are typically compatible with a specific MC version or older versions, such as `1.7.2` or `1.8.9`. Check the mods website for more information.
+
+[Impact]: https://impactclient.net/
+[Impact Issues]: https://github.com/ImpactDevelopment/ImpactIssues
+
+[Seppuku]: https://seppuku.pw/
+[Seppuku Discord]: https://discord.gg/nf8Dfj4
+[Seppuku GitHub]: https://github.com/seppukudevelopment/seppuku
+
+
+#### Archived & WIP (Forge)
+<details>
+<summary><em>Expand list</em></summary>
+
+| Name | Version | Links | Status |
+| :--: | :-----: | :---: | :----: |
+| FiraClient | **1.12.2** | [GitHub][Fira GitHub] | Archived |
+| Gamesense | **1.12.2** | [GitHub][OG GS GitHub] | Archived |
+| [Kami Blue] | **1.12.2** | [GitHub][KB GitHub] | Archived |
+| Luchadora | **1.12.2** | [GitHub][Luchadora GitHub] | Archived |
+| Momentum | **1.12.2** | [GitHub][Momentum GitHub] | Archived 
+| Past | **1.12.2** | [GitHub][Past GitHub] | Archived |
+| [Postman] | **1.12.2** | [GitHub][Postman GitHub] | Archived |
+| Salhackskid | **1.12.2** | [GitHub][Salhackskid GitHub] | Archived |
+
+[Fira GitHub]: https://github.com/cout970/FiraClient
+[OG GS GitHub]: https://github.com/IUDevman/gamesense-client
+[Kami Blue]: https://kamiblue.org/
+[KB GitHub]: https://github.com/kami-blue/client
+[Luchadora GitHub]: https://github.com/x4e/Luchadora
+[Momentum GitHub]: https://github.com/linustouchtips/momentum
+[Past GitHub]: https://github.com/olliem5/past
+[Postman]: http://techale.github.io/postman-website/
+[Postman GitHub]: https://github.com/moomooooo/postman
+[Salhackskid GitHub]: https://github.com/pleasegivesource/SalHackSkid
+
+</details>
 
 
 ### Standalone
 
-| Name | Version | Support | Source | Devlopment Status |
-|:-:|:-:|:-:|:-:|:-:|
-| [Impact](https://impactclient.net) | **1.11.2-1.16.4** | N/A | Closed | Active |
-| [Sigma](https://sigmaclient.info) | **1.16.4** | [Reddit](https://www.reddit.com/r/SigmaClient) | Closed | Inactive |
+| Name | Version | Links | Notes |
+| :--: | :-----: | :---: | ----- |
+| [Sigma] | **1.8 to 1.16** | [Reddit][Sigma Reddit] |
 
-#### Archived/WIP
+[Sigma]: https://sigmaclient.info/
+[Sigma Reddit]: https://www.reddit.com/r/SigmaClient
 
-| Name | Version | Support | Source | Devlopment Status |
-|:-:|:-:|:-:|:-:|:-:|
 
-### Forge
+#### Archived & WIP (standalone)
+<details>
+<summary><em>Expand list</em></summary>
 
-| Name | Version | Support | Source | Devlopment Status |
-|:-:|:-:|:-:|:-:|:-:|
-| Cosmos | **1.12.2** | [Discord](https://discord.gg/DtrvGHDftk) | Closed | Active |
-| [seppuku](https://seppuku.pw) | **1.12.2** | [Discord](https://discord.gg/UzWBZPe) | [GitHub](https://github.com/seppukudevelopment/seppuku) | Active |
+| Name | Version | Links | Status |
+| :--: | :-----: | :---: | :----: |
+
+</details>
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@ Minecraft Utility Mod Index
 
 </div>
 
-## Contributing
-
-Please consult the [Contribution Guidelines](https://github.com/UtilityMods/Index/blob/main/CONTRIBUTING.md) before opening an Issue or a Pull Request.
-
 ## Mod index
 
 The index includes clients for Fabric, Forge, and Standalone, with version support from 1.12 to 1.17. It is alphabetically sorted by mod name and categorized by the modloader.
@@ -68,16 +64,8 @@ The index includes clients for Fabric, Forge, and Standalone, with version suppo
 | Cosmos | **1.12.2** | [Discord](https://discord.gg/DtrvGHDftk) | Closed | Active |
 | [seppuku](https://seppuku.pw) | **1.12.2** | [Discord](https://discord.gg/UzWBZPe) | [GitHub](https://github.com/seppukudevelopment/seppuku) | Active |
 
-#### Archived/WIP
+## Contributing
 
-| Name | Version | Support | Source | Devlopment Status |
-|:-:|:-:|:-:|:-:|:-:|
-| FiraClient | **1.12.2** | N/A | [GitHub](https://github.com/cout970/FiraClient) | Archived |
-| Gamesense | **1.12.2** | N/A | [GitHub](https://github.com/IUDevman/gamesense-client) | Archived |
-| [Kami Blue](https://kamiblue.org) | **1.12.2** | N/A | [GitHub](https://github.com/kami-blue/client) | Archived |
-| Luchadora | **1.12.2** | N/A | [GitHub](https://github.com/x4e/Luchadora) | Archived |
-| Momentum | **1.12.2** | N/A | [GitHub](https://github.com/linustouchtips/momentum) | Archived 
-| Past | **1.12.2** | N/A | [GitHub](https://github.com/olliem5/past) | Archived |
-| [Postman](http://techale.github.io/postman-website/) | **1.12.2** | N/A | [GitHub](https://github.com/moomooooo/postman) | Archived |
-| Salhackskid | **1.12.2** | N/A | [GitHub](https://github.com/pleasegivesource/SalHackSkid) | Archived |
+Please consult the [Contribution Guidelines] before opening an Issue or a Pull Request.
 
+[Contribution Guidelines]: https://github.com/UtilityMods/Index/blob/main/CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -12,6 +12,26 @@ Minecraft Utility Mod Index
 
 The index includes clients for Fabric, Forge, and Standalone, with version support from 1.12 to 1.17. It is alphabetically sorted by mod name and categorized by the modloader.
 
+<details>
+<summary><strong>Modloaders explained</strong> (click to expand)</summary>
+
+A modloader is exactly what it sounds like: it loads mods, hence "mod loader". These loaders make it easy for developers to write mods and even easier for players to install mods.
+
+| Modloader | Description | Website |
+| :-------: | ----------- | :-----: |
+| Fabric | Fabric is a lightweight, experimental modding toolchain for Minecraft. Much newer than Forge. | [Fabric] |
+| Forge | Arguably the most popular modding API for Minecraft. Most older (around MC 1.12) mods are written using Forge. Forge does have support for newer MC versions, but developers tend to switch to Fabric for newer MC. | [Forge] |
+| Standalone | This is a more primitive method of modding where devs don't use a dedicated modloader, and rather modify the game directly. A popular example of this style is [Optifine], which can be loaded into Minecraft without setting up any other modloaders. | *N/A* |
+
+**Please note:** Forge and Fabric are **not** designed to work alongside eachother. You are free to try it, but don't be surprised if it doesn't work and no one helps you.
+
+[Fabric]: https://www.fabricmc.net/
+[Forge]: https://files.minecraftforge.net/
+[Optifine]: https://www.optifine.net/
+
+</details>
+
+
 ### Fabric
 
 | Name | Version | Support | Source | Development Status |

--- a/README.md
+++ b/README.md
@@ -43,14 +43,15 @@ A modloader is exactly what it sounds like: it loads mods, hence "mod loader". T
 | FrostBurn       | **1.17**             | [Discord][FrostBurn Discord]<br>[GitHub][FrostBurn GitHub] |
 | [Inertia]       | **1.14.4 to 1.16.5** | [Discord][Inertia Discord] |
 | [Jex]           | **1.17**             | [Discord][Jex Discord]<br>[Github][Jex GitHub] |
-| [KAMI]*         | **1.16.5**           | [Discord][KAMI Discord]<br>[GitHub][KAMI GitHub] |
+| [KAMI]\*<sup>2</sup> | **1.16.5**      | [Discord][KAMI Discord]<br>[GitHub][KAMI GitHub] |
 | [Meteor Client] | **1.17.1**           | [Discord][Meteor Discord]<br>[GitHub][Meteor GitHub] |
-| [Quantum]       |  **1.17**            | [Discord][Quantum Discord]<br>[GitHub][Quantum GitHub]* |
+| [Quantum]       |  **1.17**            | [Discord][Quantum Discord]<br>[GitHub][Quantum GitHub]\*<sup>3</sup> |
 | Toast Client    | **1.16.5**           | [Discord][Toast Discord]<br>[GitHub][Toast GitHub] |
 | [Wurst]         | **1.7.2 to 1.17.1+**<br><small>*older versions may use Forge*</small> | [Reddit][Wurst Reddit]<br>[GitHub][Wurst GitHub] |
 
 \* KAMI should **not** be confused with the "Kami Blue" utility mod, which has been archived and is no longer maintained.  
-\* Quantum itself is not open-source, but the developers have published the source code for some tools Quantum uses.
+\*<sup>2</sup> KAMI should **not** be confused with the "Kami Blue" utility mod, which has been archived and is no longer maintained.  
+\*<sup>3</sup> Quantum itself is not open-source, but the developers have published the source code for some tools Quantum uses.
 
 [Aristois]: https://aristois.net/
 [Aristois forum]: https://discuss.aristois.net/
@@ -101,7 +102,7 @@ A modloader is exactly what it sounds like: it loads mods, hence "mod loader". T
 
 | Name | Version | Links | Status |
 | :--: | :-----: | :---: | :----: |
-| [beach house]  |  **1.16.5?**  | [GitHub][beach house GitHub]* | WIP |
+| [beach house]  |  **1.16.5?**  | [GitHub][beach house GitHub]\*<sup>1</sup> | WIP |
 | Bleach epearl edition | **1.16.4** | [Discord][Bleach epearl Discord]<br>[GitHub][Bleach epearl GitHub] | Archived |
 | BubbyClient    | **1.16.1**   | [GitHub][Bubby GitHub] | Archived |
 | [Cornos]       | **1.16.5**   | [Discord][Cornos Discord]<br>[GitHub][Cornos GitHub] | Archived |
@@ -113,7 +114,7 @@ A modloader is exactly what it sounds like: it loads mods, hence "mod loader". T
 | Numa           |  **1.16.5**  | [Forum][Numa Forum]<br>*may be offline* | WIP |
 | Phobos-1.16    | **1.16.5**   | [Github][Phobos-1.16 GitHub] | Archived |
 
-\* beach house itself is not open-source, but the developers have published the source code for some tools beach house uses.
+\*<sup>1</sup> beach house itself is not open-source, but the developers have published the source code for some tools beach house uses.
 
 [beach house]: https://beach-house-development.github.io/website/
 [beach house GitHub]: https://github.com/beach-house-development
@@ -142,11 +143,11 @@ A modloader is exactly what it sounds like: it loads mods, hence "mod loader". T
 
 | Name | Version | Links |
 | :--: | :-----: | :---: |
-| [Impact]* | **1.11.2 to 1.16.5** | [Issues][Impact Issues]* |
+| [Impact]\*<sup>1</sup> | **1.11.2 to 1.16.5** | [Issues][Impact Issues]\*<sup>2</sup> |
 | [Seppuku] | **1.12.2** | [Discord][Seppuku Discord]<br>[GitHub][Seppuku GitHub] |
 
-\* Impact is also available as a standalone mod.
-\* Impact previously had a Discord server but it was terminated in a Discord ban-wave.
+\*<sup>1</sup> Impact is also available as a standalone mod.
+\*<sup>2</sup> Impact previously had a Discord server but it was terminated in a Discord ban-wave.
 
 #### Fabric mods with Forge variants
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Minecraft Utility Mod Index
 
 </div>
 
+## Contributing
+
+Please consult the [Contribution Guidelines](https://github.com/UtilityMods/Index/blob/main/CONTRIBUTING.md) before opening an Issue or a Pull Request.
 
 ### Fabric
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ A modloader is exactly what it sounds like: it loads mods, hence "mod loader". T
 | Toast Client    | **1.16.5**           | [Discord][Toast Discord]<br>[GitHub][Toast GitHub] |
 | [Wurst]         | **1.7.2 to 1.17.1+**\*<sup>1</sup> | [Reddit][Wurst Reddit]<br>[GitHub][Wurst GitHub] |
 
-\*<sup>1</sup> Older Minecraft versions may be using Forge.
+\*<sup>1</sup> Older Minecraft versions may be using Forge.  
 \*<sup>2</sup> KAMI should **not** be confused with the "Kami Blue" utility mod, which has been archived and is no longer maintained.  
-\*<sup>3</sup> Quantum itself is not open-source, but the developers have published the source code for some tools Quantum uses.
+\*<sup>3</sup> Quantum itself is not open-source, but the developers have published the source code for some tools Quantum uses.  
 
 [Aristois]: https://aristois.net/
 [Aristois forum]: https://discuss.aristois.net/
@@ -114,7 +114,7 @@ A modloader is exactly what it sounds like: it loads mods, hence "mod loader". T
 | Numa           |  **1.16.5**  | [Forum][Numa Forum]<br>*may be offline* | WIP |
 | Phobos-1.16    | **1.16.5**   | [Github][Phobos-1.16 GitHub] | Archived |
 
-\*<sup>1</sup> beach house itself is not open-source, but the developers have published the source code for some tools beach house uses.
+\*<sup>1</sup> beach house itself is not open-source, but the developers have published the source code for some tools beach house uses.  
 
 [beach house]: https://beach-house-development.github.io/website/
 [beach house GitHub]: https://github.com/beach-house-development
@@ -146,8 +146,8 @@ A modloader is exactly what it sounds like: it loads mods, hence "mod loader". T
 | [Impact]\*<sup>1</sup> | **1.11.2 to 1.16.5** | [Issues][Impact Issues]\*<sup>2</sup> |
 | [Seppuku] | **1.12.2** | [Discord][Seppuku Discord]<br>[GitHub][Seppuku GitHub] |
 
-\*<sup>1</sup> Impact is also available as a standalone mod.
-\*<sup>2</sup> Impact previously had a Discord server but it was terminated in a Discord ban-wave.
+\*<sup>1</sup> Impact is also available as a standalone mod.  
+\*<sup>2</sup> Impact previously had a Discord server but it was terminated in a Discord ban-wave.  
 
 #### Fabric mods with Forge variants
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Minecraft Utility Mod Index
 
 ## Mod index
 
-The index includes clients for Fabric, Forge, and Standalone, with version support from 1.12 to 1.17. It is alphabetically sorted by mod name and categorized by the modloader.
+The index includes clients for [Fabric](#fabric) and [Forge](#forge) (as well as [Standalone](#standalone) mods). It is alphabetically sorted by mod name and categorized by the modloader.
 
 <details>
 <summary><strong>Modloaders explained</strong> (click to expand)</summary>

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A modloader is exactly what it sounds like: it loads mods, hence "mod loader". T
 | Name | Version | Links |
 | :--: | :-----: | :---: |
 | [Ares]          | **1.16.4**           | [Discord][Ares Discord]<br>[GitHub][Ares GitHub] |
-| [Aristois]      | **1.8.9 to 1.17.1**<br><small>*older versions may use Forge*</small> | [Forum][Aristois forum] |
+| [Aristois]      | **1.8.9 to 1.17.1**\*<sup>1</sup> | [Forum][Aristois forum] |
 | Atomic          | **1.17**             | [Discord][Atomic Discord]<br>[GitHub][Atmoic GitHub] |
 | [Bleach]        | **1.16.5 to 1.17.1** | [Discord][Bleach Discord]<br>[GitHub][Bleach GitHub] |
 | FrostBurn       | **1.17**             | [Discord][FrostBurn Discord]<br>[GitHub][FrostBurn GitHub] |
@@ -47,9 +47,9 @@ A modloader is exactly what it sounds like: it loads mods, hence "mod loader". T
 | [Meteor Client] | **1.17.1**           | [Discord][Meteor Discord]<br>[GitHub][Meteor GitHub] |
 | [Quantum]       |  **1.17**            | [Discord][Quantum Discord]<br>[GitHub][Quantum GitHub]\*<sup>3</sup> |
 | Toast Client    | **1.16.5**           | [Discord][Toast Discord]<br>[GitHub][Toast GitHub] |
-| [Wurst]         | **1.7.2 to 1.17.1+**<br><small>*older versions may use Forge*</small> | [Reddit][Wurst Reddit]<br>[GitHub][Wurst GitHub] |
+| [Wurst]         | **1.7.2 to 1.17.1+**\*<sup>1</sup> | [Reddit][Wurst Reddit]<br>[GitHub][Wurst GitHub] |
 
-\* KAMI should **not** be confused with the "Kami Blue" utility mod, which has been archived and is no longer maintained.  
+\*<sup>1</sup> Older Minecraft versions may be using Forge.
 \*<sup>2</sup> KAMI should **not** be confused with the "Kami Blue" utility mod, which has been archived and is no longer maintained.  
 \*<sup>3</sup> Quantum itself is not open-source, but the developers have published the source code for some tools Quantum uses.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Minecraft Utility Mod Index
 ===
 ***A public index of all (known) Minecraft utility mods***
 
-**`Last updated: 2021-07-24`**
+**`Last updated: 2021-07-25`**
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Index of all Minecraft Utility Mods:
-*(we know of)
+<div align="center">
 
-## Contributions
-If you wish to contribute consult [CONTRIBUTING.md](https://github.com/UtilityMods/Index/blob/main/CONTRIBUTING.md)
+Minecraft Utility Mod Index
+===
+***A public index of all (known) Minecraft utility mods***
 
-## Index
+**`Last updated: 2021-07-22`**
 
-Sorted: *A-Z*     
-Last updated 22/07/2021
+</div>
+
 
 ### Fabric
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Minecraft Utility Mod Index
 ===
 ***A public index of all (known) Minecraft utility mods***
 
-**`Last updated: 2021-07-22`**
+**`Last updated: 2021-07-24`**
 
 </div>
 


### PR DESCRIPTION
<h1>

**TL;DR** [it looks like this now]

</h1>

# Summary of changes

Please let me know if you have any questions about what I did; I'm extremely comfortable with Markdown so I should be able to answer most of them.

- Improved header with centering & better styling
- Improved Contributing section by putting it at the bottom (standard practice)
   - Also overhauled [CONTRIBUTING.md] (click to see changes on my repo)
- Added proper description
- Added collabseible section for "Modloaders explained"
- Completely overhauled actual index part of the index:
   - Three main sections are divided by separators
   - Fixed tables
   - Switched all links (except in-page references) to [Markdown reference links]
   - Archive/WIP sections are now collapsed by default (click to expand)
   - Removed some really old or irrelevant mods
   - Updated website, Discord, and GitHub information for many mods
   - Improved general Markdown readability (dummy spacing on tables, newlines between reference link groups, etc.)
- Probably more that I forgot about
- Why did I spend so much time on this
- I don't get out much huh

[it looks like this now]: https://github.com/tycrek/Index
[CONTRIBUTING.md]: https://github.com/tycrek/Index/blob/main/CONTRIBUTING.md
[Markdown reference links]: https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#links